### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *


### PR DESCRIPTION
This e.g. allows downstream distributions to use your test suite as integration tests, to check whether the packaged versions of pdfx's dependencies are compatible.