### PR TITLE
Detects pdf URLs that end with parameters (e.g. ?dl=1 on dropbox)

### DIFF
--- a/pdfx/backends.py
+++ b/pdfx/backends.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 import sys
 import logging
 from io import BytesIO
+from re import compile
 
 # Character Detection Helper
 import chardet
@@ -82,8 +83,10 @@ class Reference(object):
         self.reftype = "url"
         self.page = page
 
+        self.pdf_regex = compile(r'\.pdf(:?\?.*)?$')
+
         # Detect reftype by filetype
-        if uri.lower().endswith(".pdf"):
+        if self.pdf_regex.search(uri.lower()):
             self.reftype = "pdf"
             return
 

--- a/pdfx/downloader.py
+++ b/pdfx/downloader.py
@@ -108,7 +108,7 @@ def download_urls(urls, output_directory, verbose=True,
 
     def download_url(url):
         try:
-            fn = url.split("/")[-1]
+            fn = url.split("/")[-1].split("?")[0]
             fn_download = os.path.join(output_directory, fn)
             with open(fn_download, "wb") as f:
                 request = Request(sanitize_url(url))


### PR DESCRIPTION
Hi Chris,

This is a small change to correctly identify pdf links if they have a set of parameters after the ".pdf".

cheers,
d