### PR TITLE
Adding a close() method and context manager methods for class PDFx

### DIFF
--- a/pdfx/__init__.py
+++ b/pdfx/__init__.py
@@ -205,3 +205,13 @@ class PDFx(object):
 
         # Download urls as a set to avoid duplicates
         download_urls(urls, dir_referenced_pdfs)
+
+    def close(self):
+        if self.stream:
+            self.stream.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()


### PR DESCRIPTION
Currently the PDFx class does not provide any means to ellegantly close the IO stream after the end of it's usage, which prevents deleting files or moving them somewhere else.

Here is a proposal to add a `close()` method and a context manager.