### PR TITLE
Changed desc.getchildren() to desc.iter()

### DIFF
--- a/pdfx/libs/xmp.py
+++ b/pdfx/libs/xmp.py
@@ -48,7 +48,7 @@ class XmpParser(object):
         """ A dictionary of all the parsed metadata. """
         meta = defaultdict(dict)
         for desc in self.rdftree.findall(RDF_NS+'Description'):
-            for el in desc.getchildren():
+            for el in desc.iter():		# getchildren() is deprecated since python 2.7 and 3.2, fixed it
                 ns, tag = self._parse_tag(el)
                 value = self._parse_value(el)
                 meta[ns][tag] = value


### PR DESCRIPTION
Now pdfx will also run with newer Python versions installed.