### PR TITLE
Fixed handling of multi-line link extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,5 +176,4 @@ Feedback, ideas and pull requests are welcome!
 Possible:
 
 - Timeout (see [#43](https://github.com/metachris/pdfx/issues/43))
-- Cuts off links that span two lines [#40](https://github.com/metachris/pdfx/issues/40)
 - Include Check-Links Results in Output [#39](https://github.com/metachris/pdfx/issues/39)

--- a/pdfx/__init__.py
+++ b/pdfx/__init__.py
@@ -33,7 +33,7 @@ License: GPLv3
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 __title__ = "pdfx"
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 __author__ = "Chris Hager"
 __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2015 Chris Hager"

--- a/pdfx/extractor.py
+++ b/pdfx/extractor.py
@@ -23,6 +23,7 @@ URL_REGEX = r"""(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|
 
 
 def extract_urls(text):
+    # Remove line breaks in order to include links spanning over multiple lines
     text = text.replace("\n", "")
     return set(re.findall(URL_REGEX, text, re.IGNORECASE))
 

--- a/pdfx/extractor.py
+++ b/pdfx/extractor.py
@@ -23,6 +23,7 @@ URL_REGEX = r"""(?i)\b((?:https?:(?:/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|
 
 
 def extract_urls(text):
+    text = text.replace("\n", "")
     return set(re.findall(URL_REGEX, text, re.IGNORECASE))
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="1.4.1",
+    version="1.4.2",
     description="Extract metadata and URLs from PDF files"
     ", and download all referenced PDFs",
     long_description=long_description,


### PR DESCRIPTION
Improved the extract_links function to include hyperlinks spanning over two or more lines by replacing line breaks in text (issue #40)